### PR TITLE
refactor: use async-await instead of promises, remove lodash

### DIFF
--- a/packages/gatsby-theme-darklight-blog/gatsby-node.js
+++ b/packages/gatsby-theme-darklight-blog/gatsby-node.js
@@ -1,7 +1,4 @@
 const fs = require("fs");
-const path = require("path");
-const Promise = require("bluebird");
-const _ = require("lodash");
 const { createFilePath } = require(`gatsby-source-filesystem`);
 
 exports.onPreBootstrap = ({ reporter }) => {
@@ -20,66 +17,58 @@ exports.onPreBootstrap = ({ reporter }) => {
   });
 };
 
-exports.createPages = ({ graphql, actions }) => {
+exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions;
 
-  return new Promise((resolve, reject) => {
-    const postPage = require.resolve("./src/templates/blog-post.js");
-    resolve(
-      graphql(
-        `
-          {
-            allMdx(
-              sort: {
-                fields: [frontmatter___date, frontmatter___title]
-                order: DESC
-              }
-              filter: {
-                fields: {
-                  source: { in: ["blog-default-posts", "blog-posts"] }
-                  slug: { ne: null }
-                }
-              }
-              limit: 1000
-            ) {
-              edges {
-                node {
-                  fields {
-                    slug
-                  }
-                  frontmatter {
-                    title
-                  }
-                }
-              }
+  const result = await graphql(
+    `
+      {
+        allMdx(
+          sort: {
+            fields: [frontmatter___date, frontmatter___title]
+            order: DESC
+          }
+          filter: {
+            fields: {
+              source: { in: ["blog-default-posts", "blog-posts"] }
+              slug: { ne: null }
             }
           }
-        `
-      ).then(result => {
-        if (result.errors) {
-          console.log(result.errors);
-          reject(result.errors);
-        }
-
-        // Create blog post pages.
-        const posts = result.data.allMdx.edges;
-        _.each(posts, (post, index) => {
-          const previous =
-            index === posts.length - 1 ? null : posts[index + 1].node;
-          const next = index === 0 ? null : posts[index - 1].node;
-
-          createPage({
-            path: post.node.fields.slug,
-            component: postPage,
-            context: {
-              slug: post.node.fields.slug,
-              previous,
-              next
+          limit: 1000
+        ) {
+          nodes {
+            fields {
+              slug
             }
-          });
-        });
-      })
-    );
+            frontmatter {
+              title
+            }
+          }
+        }
+      }
+    `
+  );
+
+  if (result.errors) {
+    reporter.panic(result.errors);
+  }
+
+  // Create blog post pages.
+  const posts = result.data.allMdx.nodes;
+
+  posts.forEach((post, index) => {
+    const previous = index === posts.length - 1 ? null : posts[index + 1];
+    const next = index === 0 ? null : posts[index - 1];
+
+    createPage({
+      path: post.fields.slug,
+      component: postPage,
+      context: {
+        slug: post.fields.slug,
+        previous,
+        next
+      }
+    });
   });
 };
 


### PR DESCRIPTION
This is a refactor to switch from promises to async-await, which makes things a bit more readable and is the pattern we've been moving toward in docs, etc.

It also removes lodash since it was only being used for a forEach loop.